### PR TITLE
Update to use OVN master

### DIFF
--- a/dist/images/Dockerfile.ipv6
+++ b/dist/images/Dockerfile.ipv6
@@ -1,0 +1,83 @@
+#
+# This is the OpenShift ovn overlay network image.
+# it provides an overlay network using ovs/ovn/ovn-kube
+#
+# The standard name for this image is ovn-kube
+
+# Notes:
+# This is for a development build where the ovn-kubernetes utilities
+# are built in this Dockerfile and included in the image (instead of the rpm)
+#
+# This is based on centos:7
+# openvswitch rpms are from
+# http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.0/4.el7/x86_64/
+#
+# So this file will change over time.
+
+FROM centos:7
+
+USER root
+
+ENV PYTHONDONTWRITEBYTECODE yes
+
+COPY kubernetes.repo /etc/yum.repos.d/kubernetes.repo
+RUN INSTALL_PKGS=" \
+	PyYAML bind-utils procps-ng openssl numactl-libs firewalld-filesystem \
+	libpcap kubectl \
+	iptables iproute strace socat \
+	unbound-libs \
+        " && \
+	yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+	yum clean all && rm -rf /var/cache/yum/*
+
+# Get a reasonable version of openvswitch (2.9.2 or higher)
+# docker build --build-arg rpmArch=ARCH -f Dockerfile.centos -t some_tag .
+# where ARCH can be x86_64 (default), aarch64, or ppc64le
+ARG rpmArch=x86_64
+ARG ovsVer=2.11.0
+ARG ovsSubVer=4.el7
+ARG dpdkVer=18.11.2
+ARG dpdkSubVer=1.el7
+ARG dpdkRpmUrl=http://mirror.centos.org/centos/7/extras/${rpmArch}/Packages/dpdk-${dpdkVer}-${dpdkSubVer}.${rpmArch}.rpm
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then dpdkRpmUrl=http://psw32.psw.net/altarch/7/extras/aarch64/Packages/dpdk-18.11-4.el7_6.aarch64.rpm; fi && rpm -i ${dpdkRpmUrl}
+RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
+RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-devel-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
+#RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-common-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
+RUN rpm -i http://www.russellbryant.net/ovn/ovn-2.12.90-1.el7.x86_64.rpm
+RUN rpm -i http://www.russellbryant.net/ovn/ovn-debuginfo-2.12.90-1.el7.x86_64.rpm
+#RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-central-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
+RUN rpm -i http://www.russellbryant.net/ovn/ovn-central-2.12.90-1.el7.x86_64.rpm
+#RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-host-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
+RUN rpm -i http://www.russellbryant.net/ovn/ovn-host-2.12.90-1.el7.x86_64.rpm
+#RUN rpm -i http://cbs.centos.org/kojifiles/packages/openvswitch/${ovsVer}/${ovsSubVer}/${rpmArch}/openvswitch-ovn-vtep-${ovsVer}-${ovsSubVer}.${rpmArch}.rpm
+RUN rpm -i http://www.russellbryant.net/ovn/ovn-vtep-2.12.90-1.el7.x86_64.rpm
+
+RUN rm -rf /var/cache/yum
+
+RUN mkdir -p /var/run/openvswitch
+
+# Built in ../../go_controller, then the binaries are copied here.
+# put things where they are in the rpm
+RUN mkdir -p /usr/libexec/cni/
+COPY ovnkube ovn-kube-util /usr/bin/
+COPY ovn-k8s-cni-overlay /usr/libexec/cni/ovn-k8s-cni-overlay
+
+# ovnkube.sh is the entry point. This script examines environment
+# variables to direct operation and configure ovn
+COPY ovnkube.sh /root/
+COPY ovn-debug.sh /root/
+# override the rpm's ovn_k8s.conf with this local copy
+COPY ovn_k8s.conf /etc/openvswitch/ovn_k8s.conf
+
+# copy git commit number into image
+COPY git_info /root
+
+
+LABEL io.k8s.display-name="ovn kubernetes" \
+      io.k8s.description="This is a component of OpenShift Container Platform that provides an overlay network using ovn." \
+      io.openshift.tags="openshift" \
+      maintainer="Phil Cameron <pcameron@redhat.com>"
+
+WORKDIR /root
+ENTRYPOINT /root/ovnkube.sh

--- a/dist/images/Makefile
+++ b/dist/images/Makefile
@@ -32,6 +32,11 @@ centos: bld
 	# docker push docker.io/ovnkube/ovn-daemonset:latest
 	./daemonset.sh --image=docker.io/ovnkube/ovn-daemonset:latest
 
+ipv6: bld
+	docker build -t ovn-kube-ipv6 -f Dockerfile.ipv6 .
+	docker tag ovn-kube-ipv6 quay.io/rbryant/ovn-kubernetes:latest
+	./daemonset.sh --image=quay.io/rbryant/ovn-kubernetes:latest
+
 fedora: bld
 	docker build -t ovn-kube-f -f Dockerfile.fedora .
 	# docker login -u ovnkube docker.io/ovnkube

--- a/go-controller/etc/ovn_k8s.conf
+++ b/go-controller/etc/ovn_k8s.conf
@@ -3,7 +3,7 @@ mtu=1400
 conntrack-zone=64000
 
 [Logging]
-logfile=/var/log/openvswitch/ovn-k8s-cni-overlay.log
+logfile=/var/log/ovn/ovn-k8s-cni-overlay.log
 loglevel=4
 
 [CNI]

--- a/go-controller/pkg/cluster/node.go
+++ b/go-controller/pkg/cluster/node.go
@@ -24,7 +24,7 @@ import (
 )
 
 func isOVNControllerReady(name string) (bool, error) {
-	const runDir string = "/var/run/openvswitch/"
+	const runDir string = "/var/run/ovn/"
 
 	pid, err := ioutil.ReadFile(runDir + "ovn-controller.pid")
 	if err != nil {

--- a/go-controller/pkg/config/config.go
+++ b/go-controller/pkg/config/config.go
@@ -340,7 +340,7 @@ var CommonFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:  "config-file",
-		Usage: "configuration file path (default: /etc/openvswitch/ovn_k8s.conf)",
+		Usage: "configuration file path (default: /etc/ovn/ovn_k8s.conf)",
 	},
 	cli.IntFlag{
 		Name:        "mtu",
@@ -493,17 +493,17 @@ var OvnNBFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:        "nb-client-privkey",
-		Usage:       "Private key that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnnb-privkey.pem)",
+		Usage:       "Private key that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/ovn/ovnnb-privkey.pem)",
 		Destination: &cliConfig.OvnNorth.PrivKey,
 	},
 	cli.StringFlag{
 		Name:        "nb-client-cert",
-		Usage:       "Client certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnnb-cert.pem)",
+		Usage:       "Client certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/ovn/ovnnb-cert.pem)",
 		Destination: &cliConfig.OvnNorth.Cert,
 	},
 	cli.StringFlag{
 		Name:        "nb-client-cacert",
-		Usage:       "CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnnb-ca.cert)",
+		Usage:       "CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/ovn/ovnnb-ca.cert)",
 		Destination: &cliConfig.OvnNorth.CACert,
 	},
 }
@@ -519,17 +519,17 @@ var OvnSBFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:        "sb-client-privkey",
-		Usage:       "Private key that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnsb-privkey.pem)",
+		Usage:       "Private key that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/ovn/ovnsb-privkey.pem)",
 		Destination: &cliConfig.OvnSouth.PrivKey,
 	},
 	cli.StringFlag{
 		Name:        "sb-client-cert",
-		Usage:       "Client certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnsb-cert.pem)",
+		Usage:       "Client certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/ovn/ovnsb-cert.pem)",
 		Destination: &cliConfig.OvnSouth.Cert,
 	},
 	cli.StringFlag{
 		Name:        "sb-client-cacert",
-		Usage:       "CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/openvswitch/ovnsb-ca.cert)",
+		Usage:       "CA certificate that the client should use for talking to the OVN database.  Leave empty to use local unix socket. (default: /etc/ovn/ovnsb-ca.cert)",
 		Destination: &cliConfig.OvnSouth.CACert,
 	},
 }
@@ -1000,9 +1000,9 @@ func buildOvnAuth(exec kexec.Interface, northbound bool, cliAuth, confAuth *OvnA
 	}
 	if strings.HasPrefix(address, "ssl") {
 		// Set up default SSL cert/key paths
-		auth.CACert = "/etc/openvswitch/ovn" + direction + "-ca.cert"
-		auth.PrivKey = "/etc/openvswitch/ovn" + direction + "-privkey.pem"
-		auth.Cert = "/etc/openvswitch/ovn" + direction + "-cert.pem"
+		auth.CACert = "/etc/ovn/ovn" + direction + "-ca.cert"
+		auth.PrivKey = "/etc/ovn/ovn" + direction + "-privkey.pem"
+		auth.Cert = "/etc/ovn/ovn" + direction + "-cert.pem"
 	}
 	// Build the final auth config with overrides from CLI and config file
 	overrideFields(auth, confAuth)

--- a/go-controller/pkg/ovn/common.go
+++ b/go-controller/pkg/ovn/common.go
@@ -73,7 +73,7 @@ func (oc *Controller) setAddressSet(hashName string, addresses []string) {
 		return
 	}
 
-	ips := strings.Join(addresses, " ")
+	ips := "\"" + strings.Join(addresses, "\" \"") + "\""
 	_, stderr, err := util.RunOVNNbctl("set", "address_set",
 		hashName, fmt.Sprintf("addresses=%s", ips))
 	if err != nil {
@@ -105,7 +105,7 @@ func (oc *Controller) createAddressSet(name string, hashName string,
 		return
 	}
 
-	ips := strings.Join(addresses, " ")
+	ips := "\"" + strings.Join(addresses, "\" \"") + "\""
 
 	// An addressSet has already been created. Just set addresses.
 	if addressSet != "" {


### PR DESCRIPTION
This includes a new Dockerfile.ipv6 which will pull in some custom RPMs built from OVN master.

Some paths needed to be updated to reflect OVN being split out from OVS.

Finally, this includes the fix submitted here: https://github.com/ovn-org/ovn-kubernetes/pull/896